### PR TITLE
fix: 修复ios设备上长按地图点呼出菜单导致选中其它元素的问题

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,17 +8,8 @@
     "i18n-ally.enabledParsers": [
         "ts"
     ],
-    "i18n-ally.extract.autoDetect": true,
+    "i18n-ally.extract.autoDetect": false,
     "i18n-ally.sourceLanguage": "zh-CN",
     "i18n-ally.keystyle": "nested",
     "i18n-ally.fullReloadOnChanged": true,
-    "i18n-ally.extract.ignoredByFiles": {
-        "src\\pages\\General.svelte": [
-            " changeLang(event.detail.lang)} />\n    ",
-            " {\n      const hiddens = localStorage.getItem('hidden')?.split('|');\n      if (hiddens.length === 0) {\n        alert($t('general.theresNoHiddenPointByNow'));\n      } else {\n        const r = confirm($t('general.therereSomeHiddenPoints').replace('{count}', hiddens.length.toString()));\n        if (r === true) {\n          localStorage.setItem('hidden', '');\n          alert($t('general.hiddenPointYattaze'));\n        }\n      }\n    }}>⚠{$t('general.clearHiddenPointButton')}⚠"
-        ]
-    },
-    "i18n-ally.extract.ignored": [
-        " {\n          is_underground = !is_underground;\n          //refreshAllMarkers();\n          refreshCollectedMarkers();\n        }}\n      >\n        "
-    ],
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -20,7 +20,7 @@
 {#if $isLoading}
   Loading...
 {:else}
-  <div style="height: 100%; ">
+  <div style="height: 100%;{$location=='/' && '-webkit-user-select: none;user-select: auto;'}">
     <!--菜单栏-->
     <nav class="menu">
       {#each menuItems as item}

--- a/src/components/MapViewComponents/RightMenu.svelte
+++ b/src/components/MapViewComponents/RightMenu.svelte
@@ -1,4 +1,4 @@
-<script lang="typescript">
+<script lang="ts">
   import { t } from 'svelte-i18n';
   import { fly } from 'svelte/transition';
 

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -27,7 +27,7 @@
 </script>
 
 {#if visible}
-  <div id="container" style="z-index: {zindex};">
+  <div id="container" style="z-index: {zindex};{ visible && '-webkit-user-select: auto;'}">
     <div id="bg" style="background-color: {backgroundColor}; opacity: {backgroundOpacity}" transition:fade={{ duration: 300 }} on:outroend={onFlyOutEnd} />
 
     <div class="modal" style="width: {width}; top: {top};" transition:fly={{ y: 200, duration: 300 }}>


### PR DESCRIPTION
## bug

ios浏览器中长按发生选中，如果当前元素不能被选中，则会选中下一个可选中的目标，会导致长按地图点呼出菜单时选中其它元素，参考[iOS Safari: How to disable long-press text selection?](https://www.reddit.com/r/webdev/comments/g1wvsb/ios_safari_how_to_disable_longpress_text_selection/)

## 解决方法

在地图页时设置顶级div `-webkit-user-select: none;`，Modal对话框打开时可能需要选中文本，再设置其为`-webkit-user-select: auto;`，会导致ios设备上地图页除了modal窗口外（主要是左侧筛选栏，应该也不怎么需要选中吧🥲）均无法进行选中。

## ipad safari测试
修复前：
![修复前](https://user-images.githubusercontent.com/52597061/160270216-69eee40b-3e2b-4412-b851-b694f73edb7e.png)
修复后：
![修复后](https://user-images.githubusercontent.com/52597061/160270218-9f84017b-7c24-4e9e-b65e-887bae9db1a4.png)

